### PR TITLE
Add "_FIELD" suffix to ParseField constants

### DIFF
--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
@@ -41,9 +41,9 @@ public class StoredLtrModel implements StorableElement {
     public static final String TYPE = "model";
 
     private static final ObjectParser<ParsingState, Void> PARSER;
-    private static final ParseField NAME = new ParseField("name");
-    private static final ParseField FEATURE_SET = new ParseField("feature_set");
-    private static final ParseField MODEL = new ParseField("model");
+    private static final ParseField NAME_FIELD = new ParseField("name");
+    private static final ParseField FEATURE_SET_FIELD = new ParseField("feature_set");
+    private static final ParseField MODEL_FIELD = new ParseField("model");
 
     private final String name;
     private final StoredFeatureSet featureSet;
@@ -53,12 +53,12 @@ public class StoredLtrModel implements StorableElement {
 
     static {
         PARSER = new ObjectParser<>(TYPE, ParsingState::new);
-        PARSER.declareString(ParsingState::setName, NAME);
+        PARSER.declareString(ParsingState::setName, NAME_FIELD);
         PARSER.declareObject(ParsingState::setFeatureSet,
                 (parser, ctx) -> StoredFeatureSet.parse(parser),
-                FEATURE_SET);
+                FEATURE_SET_FIELD);
         PARSER.declareObject(ParsingState::setRankingModel, LtrModelDefinition.PARSER,
-                MODEL);
+                MODEL_FIELD);
     }
 
     public StoredLtrModel(String name, StoredFeatureSet featureSet, LtrModelDefinition definition) {
@@ -156,10 +156,10 @@ public class StoredLtrModel implements StorableElement {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(NAME.getPreferredName(), name);
-        builder.field(FEATURE_SET.getPreferredName());
+        builder.field(NAME_FIELD.getPreferredName(), name);
+        builder.field(FEATURE_SET_FIELD.getPreferredName());
         featureSet.toXContent(builder, params);
-        builder.startObject(MODEL.getPreferredName());
+        builder.startObject(MODEL_FIELD.getPreferredName());
         builder.field(LtrModelDefinition.MODEL_TYPE.getPreferredName(), rankingModelType);
         builder.field(LtrModelDefinition.MODEL_DEFINITION.getPreferredName());
         if (modelAsString) {

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -54,22 +54,22 @@ import com.o19s.es.ltr.utils.FeatureStoreLoader;
  */
 public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBuilder> implements NamedWriteable {
     public static final String NAME = "sltr";
-    public static final ParseField MODEL_NAME = new ParseField("model");
-    public static final ParseField FEATURESET_NAME = new ParseField("featureset");
-    public static final ParseField STORE_NAME = new ParseField("store");
-    public static final ParseField PARAMS = new ParseField("params");
-    public static final ParseField ACTIVE_FEATURES = new ParseField("active_features");
+    public static final ParseField MODEL_NAME_FIELD = new ParseField("model");
+    public static final ParseField FEATURESET_NAME_FIELD = new ParseField("featureset");
+    public static final ParseField STORE_NAME_FIELD = new ParseField("store");
+    public static final ParseField PARAMS_FIELD = new ParseField("params");
+    public static final ParseField ACTIVE_FEATURES_FIELD = new ParseField("active_features");
     private static final ObjectParser<StoredLtrQueryBuilder, Void> PARSER;
 
     public static final Logger LOGGER = Loggers.getLogger(StoredLtrQueryBuilder.class);
 
     static {
         PARSER = new ObjectParser<>(NAME);
-        PARSER.declareString(StoredLtrQueryBuilder::modelName, MODEL_NAME);
-        PARSER.declareString(StoredLtrQueryBuilder::featureSetName, FEATURESET_NAME);
-        PARSER.declareString(StoredLtrQueryBuilder::storeName, STORE_NAME);
-        PARSER.declareField(StoredLtrQueryBuilder::params, XContentParser::map, PARAMS, ObjectParser.ValueType.OBJECT);
-        PARSER.declareStringArray(StoredLtrQueryBuilder::activeFeatures, ACTIVE_FEATURES);
+        PARSER.declareString(StoredLtrQueryBuilder::modelName, MODEL_NAME_FIELD);
+        PARSER.declareString(StoredLtrQueryBuilder::featureSetName, FEATURESET_NAME_FIELD);
+        PARSER.declareString(StoredLtrQueryBuilder::storeName, STORE_NAME_FIELD);
+        PARSER.declareField(StoredLtrQueryBuilder::params, XContentParser::map, PARAMS_FIELD, ObjectParser.ValueType.OBJECT);
+        PARSER.declareStringArray(StoredLtrQueryBuilder::activeFeatures, ACTIVE_FEATURES_FIELD);
         AbstractQueryBuilderUtils.declareStandardFields(PARSER);
     }
 
@@ -111,10 +111,10 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
             throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
         }
         if (builder.modelName() == null && builder.featureSetName() == null) {
-            throw new ParsingException(parser.getTokenLocation(), "Either [" + MODEL_NAME + "] or [" + FEATURESET_NAME + "] must be set.");
+            throw new ParsingException(parser.getTokenLocation(), "Either [" + MODEL_NAME_FIELD + "] or [" + FEATURESET_NAME_FIELD + "] must be set.");
         }
         if (builder.params() == null) {
-            throw new ParsingException(parser.getTokenLocation(), "Field [" + PARAMS + "] is mandatory.");
+            throw new ParsingException(parser.getTokenLocation(), "Field [" + PARAMS_FIELD + "] is mandatory.");
         }
         return builder;
     }
@@ -134,19 +134,19 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     protected void doXContent(XContentBuilder builder, Params p) throws IOException {
         builder.startObject(NAME);
         if (modelName != null) {
-            builder.field(MODEL_NAME.getPreferredName(), modelName);
+            builder.field(MODEL_NAME_FIELD.getPreferredName(), modelName);
         }
         if (featureSetName != null) {
-            builder.field(FEATURESET_NAME.getPreferredName(), featureSetName);
+            builder.field(FEATURESET_NAME_FIELD.getPreferredName(), featureSetName);
         }
         if (storeName != null) {
-            builder.field(STORE_NAME.getPreferredName(), storeName);
+            builder.field(STORE_NAME_FIELD.getPreferredName(), storeName);
         }
         if (this.params != null && !this.params.isEmpty()) {
-            builder.field(PARAMS.getPreferredName(), this.params);
+            builder.field(PARAMS_FIELD.getPreferredName(), this.params);
         }
         if (this.activeFeatures != null && !this.activeFeatures.isEmpty()) {
-            builder.field(ACTIVE_FEATURES.getPreferredName(), this.activeFeatures);
+            builder.field(ACTIVE_FEATURES_FIELD.getPreferredName(), this.activeFeatures);
         }
         printBoostAndQueryName(builder);
         builder.endObject();

--- a/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
@@ -59,7 +59,7 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
             StoredLtrModel.TYPE)));
 
     public static final String NAME = "validating_ltr_query";
-    private static final ParseField VALIDATION = new ParseField("validation");
+    private static final ParseField VALIDATION_FIELD = new ParseField("validation");
     private static final ObjectParser<ValidatingLtrQueryBuilder, Void> PARSER = new ObjectParser<>(NAME);
 
     static {
@@ -133,7 +133,7 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
                         "] is mandatory.");
             }
             if (builder.validation == null) {
-                throw new ParsingException(parser.getTokenLocation(), "Expected field [" + VALIDATION.getPreferredName() + "]");
+                throw new ParsingException(parser.getTokenLocation(), "Expected field [" + VALIDATION_FIELD.getPreferredName() + "]");
             }
 
             return builder;
@@ -153,7 +153,7 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
         builder.field(element.type(), element);
-        builder.field(VALIDATION.getPreferredName(), validation);
+        builder.field(VALIDATION_FIELD.getPreferredName(), validation);
         printBoostAndQueryName(builder);
         builder.endObject();
     }

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -76,7 +76,7 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
      */
     @Override
     protected Set<String> getObjectsHoldingArbitraryContent() {
-        return Collections.singletonMap(StoredLtrQueryBuilder.PARAMS.getPreferredName(), null).keySet();
+        return Collections.singletonMap(StoredLtrQueryBuilder.PARAMS_FIELD.getPreferredName(), null).keySet();
     }
 
     @Before


### PR DESCRIPTION
To prevent any misunderstanding/clash with other fields defined in the same classes.
Detected as BLOCKER issues by Sonar.